### PR TITLE
Stability patch

### DIFF
--- a/Listrr/Jobs/BackgroundJobs/ProcessMovieListBackgroundJob.cs
+++ b/Listrr/Jobs/BackgroundJobs/ProcessMovieListBackgroundJob.cs
@@ -61,7 +61,13 @@ namespace Listrr.Jobs.BackgroundJobs
             }
             catch (TraktListNotFoundException)
             {
-                await _traktService.Delete(new TraktList { Id = param });
+                await _traktService.Delete(new TraktList {Id = param});
+            }
+            catch (TraktAuthorizationException)
+            {
+                traktList = await _traktService.Get(param);
+                traktList.LastProcessed = DateTime.Now;
+                traktList.Process = false;
             }
             finally
             {

--- a/Listrr/Jobs/BackgroundJobs/ProcessShowListBackgroundJob.cs
+++ b/Listrr/Jobs/BackgroundJobs/ProcessShowListBackgroundJob.cs
@@ -61,7 +61,13 @@ namespace Listrr.Jobs.BackgroundJobs
             }
             catch (TraktListNotFoundException)
             {
-                await _traktService.Delete(new TraktList { Id = param });
+                await _traktService.Delete(new TraktList {Id = param});
+            }
+            catch (TraktAuthorizationException)
+            {
+                traktList = await _traktService.Get(param);
+                traktList.LastProcessed = DateTime.Now;
+                traktList.Process = false;
             }
             finally
             {

--- a/Listrr/Jobs/RecurringJobs/EnforceListLimitRecurringJob.cs
+++ b/Listrr/Jobs/RecurringJobs/EnforceListLimitRecurringJob.cs
@@ -37,7 +37,7 @@ namespace Listrr.Jobs.RecurringJobs
                 
                 if (lists.Count > limitConfig.ListLimit)
                 {
-                    foreach (var traktList in lists)
+                    foreach (var traktList in lists.Where(x => x.Process))
                     {
                         traktList.Process = false;
 
@@ -46,7 +46,7 @@ namespace Listrr.Jobs.RecurringJobs
                 }
                 else
                 {
-                    foreach (var traktList in lists)
+                    foreach (var traktList in lists.Where(x => x.Process == false))
                     {
                         traktList.Process = true;
 


### PR DESCRIPTION
- When getting a TraktAuthorizationException due to a user revoked our access, we now disable the list to get processed again.
- Update only lists that actually need to change the state of